### PR TITLE
fix chanDwn bug - short circuit eval needed

### DIFF
--- a/examples/TinyTV/TinyTV.ino
+++ b/examples/TinyTV/TinyTV.ino
@@ -233,12 +233,12 @@ void tinyTVloop() {
     getNextFile();
     startNewVideo();
   }
-  if (IRresult == chanDownCode || (checkNewButtonPress(TSButtonLowerLeft) && chanDwn) && !isPaused()) {
+if (IRresult == chanDownCode || (chanDwn && checkNewButtonPress(TSButtonLowerLeft)) && !isPaused()) {
     stopVideo();
     getPreviousFile();
     startNewVideo();
   }
-  if (IRresult == powerCode || (checkNewButtonPress(TSButtonLowerLeft) && !chanDwn)) {
+  if (IRresult == powerCode || (!chanDwn && checkNewButtonPress(TSButtonLowerLeft))) {
     if (isPaused()) {
       display.on();
       display.goTo(0, 0);


### PR DESCRIPTION
`checkNewButtonPress` / `display.getButtons` consumes the button press so subsequent calls for the same mask are ignored (or something like that). By testing for `chanDwn` flag first, the subsequent test of `checkNewButtonPress` is short circuited if the first test fails and so the button state remains available.

This solves the bug in my previous commit which prevented the "display off" code from ever being executed